### PR TITLE
Separate Contributing file

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,19 @@
+## Contributing Guidelines
+
+1. **Getting Started**:
+   - Create an account on [opensourcesports.io](https://opensourcesports.io)
+   - Familiarize yourself with the platform interface
+   - Read the documentation and existing rules
+   - Understand the submission standards
+
+2. **Code of Conduct**:
+   - Be respectful and inclusive
+   - Provide constructive feedback
+   - Follow the established guidelines
+   - Collaborate positively
+
+3. **Submission Process**:
+   - Use the opensourcesports.io platform for all submissions
+   - Follow the guided submission process
+   - Provide complete and accurate information
+   - Respond to review feedback through the platform

--- a/README.md
+++ b/README.md
@@ -382,26 +382,6 @@ The system parses repository content using these rules:
 3. **Content Processing**: Processes HTML content for rules and sections
 4. **Version Tracking**: Compares content to detect changes and update versions
 
-## Contributing Guidelines
-
-1. **Getting Started**:
-   - Create an account on [opensourcesports.io](https://opensourcesports.io)
-   - Familiarize yourself with the platform interface
-   - Read the documentation and existing rules
-   - Understand the submission standards
-
-2. **Code of Conduct**:
-   - Be respectful and inclusive
-   - Provide constructive feedback
-   - Follow the established guidelines
-   - Collaborate positively
-
-3. **Submission Process**:
-   - Use the opensourcesports.io platform for all submissions
-   - Follow the guided submission process
-   - Provide complete and accurate information
-   - Respond to review feedback through the platform
-
 ## Community Resources
 
 - **Documentation**: Complete guides at docs.opensourcesports.io


### PR DESCRIPTION
Hello,

Currently, all contribution guidelines are embedded within the main README.md, which can make them harder to find and maintain. I wanted to propose creating a dedicated CONTRIBUTING.md file to clearly outline how users can contribute, submit issues, or add new sports rules.

