### PR TITLE
[UPDATE] fix: MgCO subscript rendered raw on Sport Climbing

### DIFF
--- a/Official/Individual Sports/Sport Climbing/IFSC_Sport_Climbing_Rules.html
+++ b/Official/Individual Sports/Sport Climbing/IFSC_Sport_Climbing_Rules.html
@@ -103,7 +103,7 @@
 
       <h3>2.2 Chalk</h3>
       <ul>
-        <li><strong>Dry chalk:</strong> Magnesium carbonate (MgCO&sub3;) in powder or block form. Carried in a chalk bag worn on the waist (lead) or placed at the base of the wall (bouldering).</li>
+        <li><strong>Dry chalk:</strong> Magnesium carbonate (MgCO&#8323;) in powder or block form. Carried in a chalk bag worn on the waist (lead) or placed at the base of the wall (bouldering).</li>
         <li><strong>Liquid chalk:</strong> Magnesium carbonate suspended in alcohol solution. Applied to hands before the attempt; the alcohol evaporates, leaving a chalk layer. Permitted and commonly used, especially in bouldering.</li>
         <li><strong>Prohibited substances:</strong> Rosin, pine tar, sticky sprays, or any adhesive substance that enhances grip beyond chalk is prohibited. Tape is permitted on fingers (for skin protection) but must not enhance friction.</li>
       </ul>


### PR DESCRIPTION
The equipment list wrote magnesium carbonate as `MgCO&sub3;`.

`&sub3;` is not a valid HTML entity — the named set has `&sub;` (subset, ⊂), and subscript three is `&#8323;`. So it passed straight through the decoder and the live page literally showed **`MgCO&sub3;`** to readers.

Found by extending `rulebook-confidence-guard` to athletic rulebooks, which had never been in scope for any accuracy check — 152 of the 158 Official files. It was the only *invalid* entity in the whole corpus; the other eight the guard surfaced (`&middot;`, `&uarr;`, `&plusmn;`, `&ge;`, `&divide;`, `&asymp;`, `&ecirc;`, `&Ecirc;`) are all legitimate and are being added to the app's decoder instead of edited out of content.

One character class, no rule text changed.