### PR TITLE
[UPDATE] fix: WT Taekwondo on the June 2026 edition, with citations

### DIFF
--- a/Official/Combat Sports/Taekwondo/WT_Taekwondo_Rules.html
+++ b/Official/Combat Sports/Taekwondo/WT_Taekwondo_Rules.html
@@ -15,12 +15,12 @@
     "category": "Combat Sports",
     "type": "official",
     "organization": "World Taekwondo",
-    "source_name": "World Taekwondo (official entry point)",
-    "source_url": "https://www.worldtaekwondo.org/",
-    "version_label": "WT Competition Rules and Interpretation (September 30, 2024 edition; site recently restructured — direct /rules-wt/ deep links return 404 from WebFetch; homepage is the stable canonical entry until WT publishes a new permanent path)",
-    "effective_date": "2024-09-30",
-    "last_verified_at": "2026-05-11",
-    "confidence": 0.90,
+    "source_name": "World Taekwondo — Competition Rules & Interpretation",
+    "source_url": "https://www.worldtaekwondo.org/upload/files/2026/05/9c7b3e13-0f32-4b64-b36b-36ca01747ad3.pdf",
+    "version_label": "WT Competition Rules and Interpretation, in force as of June 1, 2026 (81pp, bilingual KO/EN, 25 Articles) — supersedes the September 30, 2024 edition this entry previously tracked",
+    "effective_date": "2026-06-01",
+    "last_verified_at": "2026-08-13",
+    "confidence": 0.95,
     "equipment": ["uniform","trunk protector","headgear","forearm guard","shin guard","groin protector","mouthguard","chest protector"],
     "contest_format": "head-to-head",
     "tags": ["olympic","professional","taekwondo","world taekwondo","martial arts"],
@@ -84,7 +84,7 @@
       <p>Competitors wear a WT-approved <strong>dobok</strong> (uniform). The dobok consists of a V-neck pullover top and elastic-waist pants, both made of lightweight, breathable fabric. The standard dobok is white. Black-collar V-neck doboks denote dan (black belt) rank holders. The competitor's name and national abbreviation are displayed on the back. The dobok must be clean, free of tears, and properly fitted &mdash; neither excessively loose (which could obscure the trunk protector) nor excessively tight.</p>
 
       <h3>2.2 Trunk Protector (Hogu)</h3>
-      <p>The <strong>trunk protector (hogu)</strong> is the primary scoring target for body techniques. In WT-sanctioned events, electronic trunk protectors integrated into the PSS are mandatory. These protectors contain sensors that register the impact force and location of strikes. One competitor wears a red (chung) protector and the other wears blue (hong), assigned by competition draw. The protector covers the torso from the base of the neck to the hipbone, protecting the front and sides. Strikes to the back of the trunk protector are not valid.</p>
+      <p>The <strong>trunk protector (hogu)</strong> is the primary scoring target for body techniques. In WT-sanctioned events, electronic trunk protectors integrated into the PSS are mandatory. These protectors contain sensors that register the impact force and location of strikes. One competitor is designated <em>Chung</em> (blue) and the other <em>Hong</em> (red), and the scoring area of the trunk protector is the blue or red coloured portion (Article 12.1.1). Permitted attacks are limited to the areas covered by the trunk protector and may not be made on the spine (Article 11.2.1).</p>
 
       <h3>2.3 Head Protector</h3>
       <p>The <strong>electronic head protector</strong> is worn over the head and covers the scoring areas above the collarbone. Since the 2020 rule cycle, WT has mandated electronic head protectors with embedded sensors at all major competitions, replacing the previous system where head kicks were scored solely by corner judges. The head protector registers valid kicks that meet the required force threshold. Red or blue head protector covers match the assigned trunk protector color.</p>
@@ -109,10 +109,10 @@
       <h2>Section 3: Playing Area</h2>
 
       <h3>3.1 Competition Mat</h3>
-      <p>Competition takes place on a regulation <strong>octagonal mat</strong> measuring <strong>8 m &times; 8 m</strong> (26.2 ft &times; 26.2 ft). The octagonal shape is created by cutting the corners of the square mat area at 45-degree angles. The mat surface must be WT-approved, constructed of shock-absorbing, non-slip material (typically EVA foam or equivalent) to minimize injury from falls and provide stable footing for kicks.</p>
+      <p>The Contest Area must have a flat surface free of obstructing projections and be covered with an elastic, non-slip mat. It may be installed on a platform 0.6&ndash;1 m high, in which case the outer part of the Outer Line is inclined at a gradient of less than 30 degrees for contestant safety (Article 3.1). <strong>Two shapes are permitted</strong> &mdash; square and octagonal (Article 3.1). The square Contest Area is <strong>8 m &times; 8 m</strong> including a 60 cm boundary line (Article 3.1.1). The octagonal Contest Area measures approximately <strong>8 m in diameter</strong>, each side of the octagon approximately 3.3 m (Article 3.1.2).</p>
 
       <h3>3.2 Boundary and Safety Zone</h3>
-      <p>The boundary line of the competition area is clearly marked in a contrasting color. Beyond the boundary, a <strong>safety zone</strong> of at least <strong>2 m (6.6 ft)</strong> extends on all sides, also covered by mat material. The safety zone prevents injury if competitors step or fall outside the boundary during exchanges. No obstacles, equipment, or spectators may encroach on the safety zone during competition.</p>
+      <p>The Competition Area envelopes both the Contest Area and the surrounding Safety Area, and shall be <strong>no smaller than 10 m &times; 10 m and no larger than 12 m &times; 12 m</strong> (Article 3.1.1). The Safety Area is therefore the margin between the outer line of the Competition Area and the boundary line of the Contest Area (Article 3.1.2) &mdash; roughly 1 m per side at the minimum Competition Area size and up to 2 m per side at the maximum. Where the Contest Area sits on a platform, the Safety Area may be increased as needed to ensure contestant safety (Article 3.1.1). The Contest Area and Safety Area may be different colours, as specified in the relevant competition's Operational Manual (Article 3.1.1).</p>
 
       <h3>3.3 Markings and Positions</h3>
       <p>Two starting positions are marked on the mat: one for the blue (chung) competitor and one for the red (hong) competitor, each approximately 4 m from the center and 1 m apart. The referee's position is marked at the center edge of the mat. Corner judge positions are designated at four corners of the competition area. An athlete designation area for each competitor (including their coach) is located outside the safety zone on opposite sides of the mat.</p>
@@ -156,7 +156,7 @@
       <h2>Section 5: Rules of Play</h2>
 
       <h3>5.1 Match Format</h3>
-      <p>A standard match consists of <strong>3 rounds of 2 minutes each</strong>, with a <strong>1-minute rest period</strong> between rounds. During the rest period, the competitor returns to their designated area, where their coach may provide instructions, water, and tactical advice. The clock stops during referee interventions (penalties, equipment adjustments, medical checks, IVR reviews).</p>
+      <p>A standard match consists of <strong>3 rounds of 2 minutes each</strong>, with a <strong>1-minute rest period</strong> between rounds (Article 7.1.1). If the score is tied after the 3rd round, a 4th round of one minute is contested as the Golden Round, after a one-minute rest following the 3rd round (Article 7.1.1). Under the best-of-three system the same three-round, two-minute structure applies, but no Golden Round is contested &mdash; a tied round is instead decided under Article 15 (Article 7.1.2). During the rest period, the competitor returns to their designated area, where their coach may provide instructions, water, and tactical advice. The clock stops during referee interventions (penalties, equipment adjustments, medical checks, IVR reviews).</p>
 
       <h3>5.2 Valid Techniques</h3>
       <p>WT taekwondo permits two categories of striking techniques:</p>
@@ -176,7 +176,7 @@
       <p>If the score is tied at the end of 3 rounds, a <strong>Golden Round (4th round)</strong> of <strong>1 minute</strong> is contested. The first competitor to score any valid point wins immediately (sudden death). If neither competitor scores during the Golden Round, the winner is determined by <strong>superiority decision</strong>: the referee and judges evaluate which competitor demonstrated greater initiative, more valid technique attempts, and more aggressive attacking throughout the entire match, including the Golden Round.</p>
 
       <h3>5.5 Point Gap Victory</h3>
-      <p>If at any point during the match one competitor leads by <strong>20 points or more</strong>, the referee stops the contest and declares that competitor the winner by point gap. This rule prevents unnecessary continuation when the outcome is no longer in doubt and protects the trailing competitor from sustained one-sided action.</p>
+      <p>Where there is a <strong>20-point difference</strong> between the two athletes <strong>at the completion of the 2nd round and/or at any time during the 3rd round</strong>, the referee stops the contest and declares the winner by point gap, PTG (Article 16, Explanation #3). The gap is therefore not applied earlier than the end of round 2. Under the best-of-three system the threshold is a <strong>15-point difference per round</strong>, and in the twelve-point variant a <strong>12-point difference per round</strong>, each decided for the corresponding round (Article 16, Explanation #3). Win by point gap <em>shall not</em> be applied in senior-division semi-finals and finals where the tournament outline so provides (Article 16, Explanation #3). The rule prevents unnecessary continuation when the outcome is no longer in doubt and protects the trailing competitor from sustained one-sided action.</p>
 
       <h3>5.6 Knockout and Referee Stop Contest</h3>
       <p>If a competitor is knocked down by a valid technique and cannot resume within a <strong>10-second count</strong> by the referee, the standing competitor wins by knockout (KO). If the referee determines a competitor is unfit to continue due to injury or accumulated damage, the match is stopped (RSC &mdash; Referee Stop Contest). A competitor who is knocked down three times in a single round from scoring techniques also loses by RSC.</p>
@@ -192,12 +192,14 @@
 
       <h3>6.2 Point Values</h3>
       <ul>
-        <li><strong>Punch to trunk protector:</strong> 1 point &mdash; delivered with the front of a closed fist (glove sensor) to the trunk protector.</li>
-        <li><strong>Kick to trunk protector:</strong> 2 points &mdash; any valid kick (foot sensor) to the trunk protector.</li>
-        <li><strong>Turning kick to trunk protector:</strong> 4 points &mdash; a kick involving 180&deg; or more of body rotation (spinning back kick, spinning side kick, etc.) striking the trunk protector.</li>
-        <li><strong>Kick to head protector:</strong> 3 points &mdash; any valid kick to the head protector.</li>
-        <li><strong>Turning kick to head protector:</strong> 5 points &mdash; a spinning or turning kick (180&deg;+ rotation) to the head protector. This is the highest-scoring single technique in taekwondo.</li>
+        <li><strong>Punch to trunk protector:</strong> 1 point (Article 12.3.1) &mdash; delivered with the front of a closed fist (glove sensor) to the trunk protector.</li>
+        <li><strong>Kick to trunk protector:</strong> 2 points (Article 12.3.2) &mdash; any valid kick (foot sensor) to the trunk protector.</li>
+        <li><strong>Kick to head:</strong> 3 points (Article 12.3.3) &mdash; any valid kick to the head.</li>
+        <li><strong>Turning kick to trunk protector:</strong> 4 points (Article 12.3.4) &mdash; a valid turning kick doubles the awarded points.</li>
+        <li><strong>Turning kick to the head:</strong> <strong>6 points</strong> (Article 12.3.4) &mdash; a valid turning kick to the head doubles the three-point head value. This is the highest-scoring single technique in taekwondo.</li>
+        <li><strong>Opponent penalised:</strong> 1 point awarded when a <em>Gam-jeom</em> is given to the opponent (Article 12.3.5).</li>
       </ul>
+      <p>Turning kicks are scored by doubling the value of the technique's target: four points to the trunk protector and <strong>six</strong> to the head (Article 12.3.4). Entries citing five points for a turning head kick reflect an edition superseded by the rules in force as of June 1, 2026.</p>
 
       <h3>6.3 Supplementary Scoring by Judges</h3>
       <p>Corner judges may award points for valid techniques that the PSS does not register electronically. This typically applies to techniques delivered at close range or unusual angles where sensor contact may be incomplete. A majority of judges must agree for a supplementary point to be awarded. The review jury may also correct obvious scoring errors identified during or after a round.</p>
@@ -210,8 +212,9 @@
       <ul>
         <li><strong>Knockout (KO):</strong> Opponent cannot rise within the 10-count.</li>
         <li><strong>Referee Stop Contest (RSC):</strong> Referee determines a competitor is unable to continue safely.</li>
-        <li><strong>Point gap:</strong> 20-point lead at any time during the match.</li>
-        <li><strong>Disqualification:</strong> Accumulation of 10 gam-jeom or instant disqualification offense.</li>
+        <li><strong>Point gap (PTG):</strong> 20-point difference at the completion of the 2nd round or any time during the 3rd (Article 16, Explanation #3).</li>
+        <li><strong>Referee's punitive declaration (PUN):</strong> Accumulation of ten Gam-jeom (Article 14.7).</li>
+        <li><strong>Disqualification (DSQ):</strong> An instant-disqualification offence, such as manipulating PSS sensor sensitivity (Article 14).</li>
         <li><strong>Withdrawal:</strong> Competitor or coach voluntarily withdraws.</li>
         <li><strong>Final score:</strong> Higher total at the end of 3 rounds.</li>
         <li><strong>Golden Round:</strong> First to score in the 4th round (1 minute).</li>
@@ -224,35 +227,29 @@
     <section id="violations-penalties">
       <h2>Section 7: Violations &amp; Penalties</h2>
 
-      <h3>7.1 Kyong-go (Warning)</h3>
-      <p>A <strong>kyong-go</strong> is a verbal warning issued by the referee for minor infractions. Two kyong-go equal one gam-jeom (one point to the opponent). A single kyong-go at the end of the match does not add to the opponent's score. Kyong-go offenses include:</p>
-      <ul>
-        <li>Crossing the boundary line with one foot (first occurrence)</li>
-        <li>Evading by turning the back to the opponent momentarily</li>
-        <li>Falling to the ground without being struck</li>
-        <li>Stalling or avoiding engagement for more than a few seconds</li>
-        <li>Grabbing, holding, or pushing the opponent's body or uniform</li>
-        <li>Lifting the knee to block without a kicking motion (excessive knee blocking)</li>
-        <li>Pretending to be injured (feigning)</li>
-      </ul>
+      <h3>7.1 Gam-jeom: a Single Penalty Class</h3>
+      <p>Penalties are declared by the referee (Article 14.1), and <strong>every prohibited act described in Article 14 is penalised with a &ldquo;Gam-jeom&rdquo;</strong> (Article 14.2). There is no separate warning tier: the <em>Kyong-go</em> warning, and the arithmetic by which two warnings converted into one penalty point, belong to a superseded edition of the rules and appear nowhere in the rules in force as of June 1, 2026.</p>
+      <p>A Gam-jeom is counted as <strong>one point for the opposing contestant</strong> (Article 14.3). The one exception is passive behaviour in the <strong>last ten seconds of a round</strong>, for which <strong>two points</strong> are awarded to the opponent (Article 14.3.1, applying Article 12.3.5.1).</p>
 
-      <h3>7.2 Gam-jeom (Penalty Point)</h3>
-      <p>A <strong>gam-jeom</strong> is a penalty deduction that awards <strong>1 point to the opponent</strong>. Gam-jeom are issued for more serious or repeated infractions:</p>
+      <h3>7.2 Prohibited Acts</h3>
+      <p>The following are classified as prohibited acts, each declared with a Gam-jeom (Article 14.4.1):</p>
       <ul>
-        <li>Attacking the opponent below the waist (kicks to the legs or groin)</li>
-        <li>Striking the opponent's back (attacking the spine area)</li>
-        <li>Punching or striking the opponent's head or face</li>
-        <li>Attacking after the referee's <em>kal-yeo</em> (stop) command</li>
-        <li>Intentionally stepping out of the boundary with both feet</li>
-        <li>Throwing or sweeping the opponent to the ground</li>
-        <li>Persistent grabbing, clinching, or pushing (after kyong-go)</li>
-        <li>Deliberately turning the back to the opponent to avoid combat</li>
-        <li>Butting or attacking with the knee</li>
-        <li>Unsportsmanlike conduct by the competitor or their coach</li>
+        <li>Crossing the Boundary Line (Article 14.4.1.1)</li>
+        <li>Falling down (Article 14.4.1.2)</li>
+        <li>Avoiding or delaying the match (Article 14.4.1.3)</li>
+        <li>Grabbing or pushing the opponent (Article 14.4.1.4)</li>
+        <li>Lifting the leg to block; kicking the opponent's leg to impede a kicking attack; aiming a kick below the waist; lifting the leg above the waist to kick in the air four or more times; or lifting a leg or kicking in the air for more than three seconds to impede the opponent (Article 14.4.1.5)</li>
+        <li>Kicking below the waist (Article 14.4.1.6)</li>
+        <li>Attacking the opponent after <em>Kal-yeo</em> (Article 14.4.1.7)</li>
+        <li>Hitting the opponent's head with the hand (Article 14.4.1.8)</li>
+        <li>Butting or attacking with the knee (Article 14.4.1.9)</li>
+        <li>Attacking the fallen opponent (Article 14.4.1.10)</li>
+        <li>Attacking the trunk PSS with the side or bottom of the foot in a clinch position (Article 14.4.1.11)</li>
       </ul>
+      <p>A Gam-jeom is recorded to the previous round if the action occurred within five seconds of that round's conclusion; misconduct by a contestant or coach during a rest period past those five seconds is declared immediately (Article 14.4).</p>
 
-      <h3>7.3 Accumulation and Disqualification</h3>
-      <p>The accumulation of <strong>10 gam-jeom</strong> during a single match results in automatic disqualification. Since each gam-jeom awards a point to the opponent, the opponent will have received at least 10 penalty points by the time disqualification occurs. Gam-jeom accumulate across all rounds of the match, including the Golden Round.</p>
+      <h3>7.3 Accumulation and Punitive Declaration</h3>
+      <p>When a contestant receives <strong>ten Gam-jeom</strong>, the referee declares that contestant the loser by <strong>referee's punitive declaration (PUN)</strong> (Article 14.7) &mdash; the rules classify this outcome as PUN rather than as a disqualification (Article 16). Under the best-of-three system, a contestant who receives <strong>five Gam-jeom in a round</strong> loses that round to the opponent (Article 14.7.1). Since each Gam-jeom awards a point to the opponent, an opponent will have accrued at least ten penalty points by the time a punitive declaration is reached.</p>
 
       <h3>7.4 Instant Disqualification</h3>
       <p>Certain severe offenses result in immediate disqualification without progressive penalties:</p>


### PR DESCRIPTION
## Why

This entry tracked the **September 30, 2024** Competition Rules. World Taekwondo has since published **Competition Rules & Interpretation, in force as of June 1, 2026** (81pp, 25 Articles). Found while starting the Official citation-density uplift — the file was two editions stale, and `source_url` pointed at the WT homepage rather than a document.

## Corrections (each verified against the June 2026 PDF)

| # | Was | Now | Source |
|---|---|---|---|
| 1 | Turning kick to head = **5 points** | **6 points** | Art 12.3.4 — turning kicks double the target value |
| 2 | `Kyong-go` warning tier; 2 warnings = 1 Gam-jeom | Single penalty class; Gam-jeom only | Art 14.2 — "Kyong-go" appears nowhere in Art 14 |
| 3 | Point gap = 20 at any time | 20 at end of R2 / during R3; 15 and 12 per-round variants; senior semi/final exemption | Art 16, Explanation #3 |
| 4 | 2 m safety zone; octagonal mat only | Square **and** octagonal permitted; Competition Area 10×10–12×12 m around an 8 m contest area (~1–2 m margin) | Art 3.1, 3.1.1, 3.1.2 |

Also fixed **Chung/Hong**: §2.2 read "red (chung) … blue (hong)" while §3.3 of the same file had it correct. Chung is blue, Hong is red.

Added: ten-second passive-behaviour exception worth **two** points (Art 14.3.1), ten Gam-jeom is a punitive declaration **PUN** not a disqualification (Art 14.7), best-of-three is five per round (Art 14.7.1), and the Gam-jeom point award (Art 12.3.5).

#1 and #2 matter most: the six-point turning head kick is the most-quoted scoring fact in the sport, and the Kyong-go tier is an entire penalty mechanic that no longer exists.

## Citation density

**0% → 35%** (31/88 claims). Still under the 70% floor so it remains warn-level debt, but it is ratcheted and may never regress from here.

## Gates

- `rulebook:confidence` — 0 errors (161 checked)
- `data-repo:validate:strict` — 0 errors, 0 warnings (195 files)
- `archetype:guard` — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)