### PR TITLE
[UPDATE] fix: judo scoring was missing yuko entirely

### DIFF
--- a/Official/Combat Sports/Judo/IJF_Judo_Rules.html
+++ b/Official/Combat Sports/Judo/IJF_Judo_Rules.html
@@ -17,10 +17,10 @@
     "organization": "IJF",
     "source_name": "IJF — Sport and Organisation Rules (SOR)",
     "source_url": "https://sor.ijf.org/",
-    "version_label": "IJF Sport and Organisation Rules (SOR), Version 24 July 2026 (2025-2028 cycle)",
-    "effective_date": "2025-02-08",
-    "last_verified_at": "2026-08-04",
-    "confidence": 0.90,
+    "version_label": "IJF Sport and Organisation Rules (SOR), Version 24 July 2026 (2025-2028 cycle) — sor.ijf.org is a permalink that redirects to whichever SOR edition is current, so it does not need re-pointing when the IJF republishes",
+    "effective_date": "2026-07-24",
+    "last_verified_at": "2026-08-13",
+    "confidence": 0.95,
     "equipment": ["mat","gi","belt"],
     "contest_format": "head-to-head",
     "tags": ["olympic","professional","judo","ijf","martial arts"],
@@ -217,33 +217,49 @@
     <section id="scoring">
       <h2>Section 6: Scoring</h2>
 
+      <p>Judo scores at three levels &mdash; <strong>ippon</strong>, <strong>waza-ari</strong> and <strong>yuko</strong>. Yuko was removed from the scoring table in the 2017 revision and has since been <strong>reinstated</strong>: in the rules in force from 21 January 2026, Article 15 is titled "Waza-ari and Yuko" and defines yuko in both standing and groundwork phases (Article 15). Any description of modern judo as a two-score sport reflects the 2017&ndash;2025 period, not the current rules.</p>
+
       <h3>6.1 Ippon (Full Point &mdash; Instant Win)</h3>
-      <p>An ippon immediately ends the match. It is awarded for any of the following:</p>
+      <p>The <strong>four criteria</strong> for ippon are speed, force, landing on the back, and skilful control maintained until the end of the landing (Article 14). Scoring requires a continuous action: if there is a stop in the action, there is no score, and the technique must be identifiable among the Kodokan classified techniques or their recognised variations (Article 14). An ippon immediately ends the match. It is awarded for:</p>
       <ul>
-        <li><strong>Throw:</strong> Executing a throwing technique that lands the opponent largely on their back with considerable force, speed, and control. All three elements must be present for ippon; the absence of any one element may reduce the score to waza-ari (Refereeing Rules Articles 14, 7).</li>
-        <li><strong>Pin (Osaekomi):</strong> Holding the opponent on their back in a controlled pin for <strong>20 seconds</strong>. The pin must immobilize the opponent's torso and prevent them from escaping or bridging free (Refereeing Rules Articles 14, 7).</li>
-        <li><strong>Submission:</strong> Forcing the opponent to tap out (submit) by verbal signal, tapping the mat or the opponent's body, or tapping with the foot. Submissions result from arm locks (elbow hyperextension) or chokes (blood/air restriction) (Refereeing Rules Articles 14, 7).</li>
-        <li><strong>Compound Waza-ari:</strong> Scoring two waza-ari in a single match. The second waza-ari is automatically upgraded to "waza-ari awasete ippon" (combined ippon), ending the match (Refereeing Rules Articles 14, 7).</li>
+        <li><strong>Throw:</strong> Throwing the opponent on the back with considerable ability and maximum efficiency. All four criteria must be present; the absence of one reduces the score to waza-ari or yuko (Article 14).</li>
+        <li><strong>Pin (Osaekomi):</strong> Holding the opponent with osaekomi-waza for <strong>20 seconds</strong> (Articles 15, 17).</li>
+        <li><strong>Submission:</strong> Forcing the opponent to tap out by verbal signal, tapping the mat or the opponent's body, or tapping with the foot. Submissions result from arm locks (elbow hyperextension) or chokes (Article 14).</li>
+        <li><strong>Waza-ari-awasete-ippon:</strong> On a second waza-ari in the contest the referee announces <em>waza-ari-awasete-ippon</em> &mdash; two waza-ari score ippon &mdash; ending the match (Article 16).</li>
       </ul>
 
-      <h3>6.2 Waza-ari (Partial Score)</h3>
-      <p>A waza-ari is awarded when a technique is effective but lacks one of the three ippon criteria (force, speed, or control). Common waza-ari scenarios include:</p>
+      <h3>6.2 Waza-ari (Near Ippon)</h3>
+      <p>Waza-ari is announced when the technique lands the opponent <strong>more than 90 degrees of the shoulder axis but not on the back</strong>, or when the four ippon criteria are not fully achieved (Article 15). A score is given for a whole side of the body landing even when the elbow is out; only the shoulder position is considered, and anything outside that range is yuko or no score (Article 15).</p>
       <ul>
-        <li>A throw that lands the opponent on their side rather than squarely on the back (Refereeing Rules Articles 15&ndash;16).</li>
-        <li>A throw with rotation but insufficient force or speed to warrant ippon (Refereeing Rules Articles 15&ndash;16).</li>
-        <li>A pin held for <strong>10 seconds or more but less than 20 seconds</strong>. The osaekomi timer runs continuously; if the pin reaches 20 seconds, it is upgraded to ippon (Refereeing Rules Articles 15&ndash;16).</li>
+        <li>A throw landing beyond 90 degrees of the shoulder axis but short of the back (Article 15).</li>
+        <li>A throw missing one of the four ippon criteria (Article 15).</li>
+        <li>A pin held for <strong>10 seconds or more but less than 20 seconds</strong> (10&ndash;19 seconds) (Articles 15, 17).</li>
       </ul>
-      <p>There is no limit to the number of waza-ari that can be scored, but the second waza-ari ends the match as a combined ippon (Refereeing Rules Articles 15&ndash;16).</p>
+      <p>The second waza-ari ends the contest as waza-ari-awasete-ippon (Article 16).</p>
 
-      <h3>6.3 Score Hierarchy and Match Outcome</h3>
-      <p>If a match reaches the end of regulation time without an ippon, the athlete with the higher score wins. The hierarchy is:</p>
+      <h3>6.3 Yuko</h3>
+      <p>Yuko &mdash; glossed in the IJF terminology as "nearly waza-ari" &mdash; is awarded in tachi-waza for (Article 15):</p>
+      <ul>
+        <li>A side landing at 90 degrees, or more toward the front landing (Article 15).</li>
+        <li>Landing on the upper back (Article 15).</li>
+        <li>Landing on the side on the shoulder axis with one elbow or one hand (Article 15).</li>
+        <li>Landing on both buttocks, close to 90 degrees to the front or 90 degrees or more to the rear &mdash; yuko, and no shido (Article 15).</li>
+        <li>Landing on one buttock, with or without the elbows or arms touching the mat (Article 15).</li>
+        <li>Landing on the neck (Article 15).</li>
+      </ul>
+      <p>Yuko is <strong>not</strong> awarded if the front of the stomach, the front of both hips, or both knees touch the mat before a side landing of 90 degrees or more toward the front (Article 15). In ne-waza, yuko is awarded for an osaekomi held <strong>5 seconds or more but less than 10 seconds</strong> (5&ndash;9 seconds) (Articles 15, 17).</p>
+      <p><strong>Yuko scores are counted individually (1, 2, 3, and so on) but never add up to a waza-ari</strong> (Article 15). No quantity of yuko can promote itself into a higher score &mdash; this is what separates the reinstated yuko from the pre-2017 accumulating scores.</p>
+
+      <h3>6.4 Score Hierarchy and Match Outcome</h3>
+      <p>If a match reaches the end of regulation time without an ippon, the athlete with the higher score wins. The levels rank:</p>
       <ol>
-        <li><strong>Ippon</strong> &mdash; immediate victory (match does not reach time) (Refereeing Rules Article 13).</li>
-        <li><strong>Waza-ari</strong> &mdash; one waza-ari beats zero waza-ari (Refereeing Rules Article 13).</li>
-        <li><strong>Fewer penalties</strong> &mdash; if scores are equal, the athlete with fewer shidos wins (Refereeing Rules Article 13).</li>
-        <li><strong>Golden Score</strong> &mdash; if scores and penalties are identical, the match enters unlimited overtime. The first score or third-shido penalty decides the winner (Refereeing Rules Article 13).</li>
+        <li><strong>Ippon</strong> &mdash; immediate victory; the match does not reach time (Article 14).</li>
+        <li><strong>Waza-ari</strong> &mdash; outranks any number of yuko (Articles 15, 16).</li>
+        <li><strong>Yuko</strong> &mdash; counted, but never aggregating into waza-ari (Article 15).</li>
+        <li><strong>Fewer penalties</strong> &mdash; with scores equal, the athlete with fewer shido wins (Article 18).</li>
+        <li><strong>Golden Score</strong> &mdash; with scores and penalties identical, the contest is decided by a golden score period (Article 16).</li>
       </ol>
-      <p>There is no draw in judo. Every match must produce a winner. In Golden Score, the Hantei (judges' decision) system has been abolished; only a concrete scoring action can decide the outcome (Refereeing Rules Article 13).</p>
+      <p>The relative weight of the three levels is explicit in the IJF's own round-robin classification, which values ippon and waza-ari-awasete-ippon at 100, waza-ari at 10, yuko at 1, and hantei at 0. There is no draw in judo; every match must produce a winner.</p>
 
       <div class="oss-section-foot"><a href="#toc" class="oss-back-top">↑ Back to Contents</a></div>
     </section>


### PR DESCRIPTION
## The defect

Our entry described judo as a **two-score sport** — ippon and waza-ari. It has **three**. Yuko was removed in the 2017 revision and has since been **reinstated**: in the SOR in force from 24 July 2026, **Article 15 is titled "Waza-ari and Yuko"** and defines it in both tachi-waza and ne-waza. The live page for an Olympic sport was missing a whole scoring level.

## What changed

**New §6.3 Yuko** — the six tachi-waza landings that earn it, the exclusion (no yuko if the stomach, both hips, or both knees touch before a side landing of 90°+ toward the front), and the ne-waza window.

**The osaekomi ladder, stated in full:**

| Hold | Score |
|---|---|
| 5–9 s | yuko |
| 10–19 s | waza-ari |
| 20 s | ippon |

**The mechanic that matters most:** yuko scores are counted individually but **never add up to a waza-ari** (Art 15). No quantity of yuko promotes itself — that's what separates the reinstated yuko from the pre-2017 accumulating scores. The hierarchy now ranks all three and cites the IJF's own round-robin values (ippon 100, waza-ari 10, yuko 1, hantei 0) as the federation's explicit statement of relative weight.

**Also corrected:** ippon had "three elements (force, speed, control)". Article 14 specifies **four** — speed, force, on the back, and skilful control maintained until the end of the landing.

## Metadata

`effective_date` was 2025-02-08 while the file's own `version_label` already said *Version 24 July 2026* — it contradicted itself. Now matches the edition it tracks.

**`source_url` is unchanged, deliberately.** `sor.ijf.org` *looks* like a bare homepage but **307-redirects to whichever SOR is current** — making it the best possible source_url, since it never needs re-pointing when the IJF republishes. Now recorded in `version_label` so nobody "fixes" it later.

## Verification

Fetched the current SOR through the permalink (Version: 24 July 2026, 298 pp): 49 yuko mentions, Article 15 present, both osaekomi windows confirmed verbatim.

Gates: `rulebook:confidence` 0 errors — **this file no longer appears in the citation-debt list at all** (corpus debt 141 → 140); `data-repo:validate:strict` 0/0; `archetype:guard` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)