### PR TITLE
[UPDATE] fix: cite badminton to the Laws, correct edition and racket Law

### DIFF
--- a/Official/Combat Sports/Judo/IJF_Judo_Rules.html
+++ b/Official/Combat Sports/Judo/IJF_Judo_Rules.html
@@ -17,10 +17,10 @@
     "organization": "IJF",
     "source_name": "IJF — Sport and Organisation Rules (SOR)",
     "source_url": "https://sor.ijf.org/",
-    "version_label": "IJF Sport and Organisation Rules (SOR), Version 24 July 2026 (2025-2028 cycle)",
-    "effective_date": "2025-02-08",
-    "last_verified_at": "2026-08-04",
-    "confidence": 0.90,
+    "version_label": "IJF Sport and Organisation Rules (SOR), Version 24 July 2026 (2025-2028 cycle) — sor.ijf.org is a permalink that redirects to whichever SOR edition is current, so it does not need re-pointing when the IJF republishes",
+    "effective_date": "2026-07-24",
+    "last_verified_at": "2026-08-13",
+    "confidence": 0.95,
     "equipment": ["mat","gi","belt"],
     "contest_format": "head-to-head",
     "tags": ["olympic","professional","judo","ijf","martial arts"],
@@ -217,33 +217,49 @@
     <section id="scoring">
       <h2>Section 6: Scoring</h2>
 
+      <p>Judo scores at three levels &mdash; <strong>ippon</strong>, <strong>waza-ari</strong> and <strong>yuko</strong>. Yuko was removed from the scoring table in the 2017 revision and has since been <strong>reinstated</strong>: in the rules in force from 21 January 2026, Article 15 is titled "Waza-ari and Yuko" and defines yuko in both standing and groundwork phases (Article 15). Any description of modern judo as a two-score sport reflects the 2017&ndash;2025 period, not the current rules.</p>
+
       <h3>6.1 Ippon (Full Point &mdash; Instant Win)</h3>
-      <p>An ippon immediately ends the match. It is awarded for any of the following:</p>
+      <p>The <strong>four criteria</strong> for ippon are speed, force, landing on the back, and skilful control maintained until the end of the landing (Article 14). Scoring requires a continuous action: if there is a stop in the action, there is no score, and the technique must be identifiable among the Kodokan classified techniques or their recognised variations (Article 14). An ippon immediately ends the match. It is awarded for:</p>
       <ul>
-        <li><strong>Throw:</strong> Executing a throwing technique that lands the opponent largely on their back with considerable force, speed, and control. All three elements must be present for ippon; the absence of any one element may reduce the score to waza-ari (Refereeing Rules Articles 14, 7).</li>
-        <li><strong>Pin (Osaekomi):</strong> Holding the opponent on their back in a controlled pin for <strong>20 seconds</strong>. The pin must immobilize the opponent's torso and prevent them from escaping or bridging free (Refereeing Rules Articles 14, 7).</li>
-        <li><strong>Submission:</strong> Forcing the opponent to tap out (submit) by verbal signal, tapping the mat or the opponent's body, or tapping with the foot. Submissions result from arm locks (elbow hyperextension) or chokes (blood/air restriction) (Refereeing Rules Articles 14, 7).</li>
-        <li><strong>Compound Waza-ari:</strong> Scoring two waza-ari in a single match. The second waza-ari is automatically upgraded to "waza-ari awasete ippon" (combined ippon), ending the match (Refereeing Rules Articles 14, 7).</li>
+        <li><strong>Throw:</strong> Throwing the opponent on the back with considerable ability and maximum efficiency. All four criteria must be present; the absence of one reduces the score to waza-ari or yuko (Article 14).</li>
+        <li><strong>Pin (Osaekomi):</strong> Holding the opponent with osaekomi-waza for <strong>20 seconds</strong> (Articles 15, 17).</li>
+        <li><strong>Submission:</strong> Forcing the opponent to tap out by verbal signal, tapping the mat or the opponent's body, or tapping with the foot. Submissions result from arm locks (elbow hyperextension) or chokes (Article 14).</li>
+        <li><strong>Waza-ari-awasete-ippon:</strong> On a second waza-ari in the contest the referee announces <em>waza-ari-awasete-ippon</em> &mdash; two waza-ari score ippon &mdash; ending the match (Article 16).</li>
       </ul>
 
-      <h3>6.2 Waza-ari (Partial Score)</h3>
-      <p>A waza-ari is awarded when a technique is effective but lacks one of the three ippon criteria (force, speed, or control). Common waza-ari scenarios include:</p>
+      <h3>6.2 Waza-ari (Near Ippon)</h3>
+      <p>Waza-ari is announced when the technique lands the opponent <strong>more than 90 degrees of the shoulder axis but not on the back</strong>, or when the four ippon criteria are not fully achieved (Article 15). A score is given for a whole side of the body landing even when the elbow is out; only the shoulder position is considered, and anything outside that range is yuko or no score (Article 15).</p>
       <ul>
-        <li>A throw that lands the opponent on their side rather than squarely on the back (Refereeing Rules Articles 15&ndash;16).</li>
-        <li>A throw with rotation but insufficient force or speed to warrant ippon (Refereeing Rules Articles 15&ndash;16).</li>
-        <li>A pin held for <strong>10 seconds or more but less than 20 seconds</strong>. The osaekomi timer runs continuously; if the pin reaches 20 seconds, it is upgraded to ippon (Refereeing Rules Articles 15&ndash;16).</li>
+        <li>A throw landing beyond 90 degrees of the shoulder axis but short of the back (Article 15).</li>
+        <li>A throw missing one of the four ippon criteria (Article 15).</li>
+        <li>A pin held for <strong>10 seconds or more but less than 20 seconds</strong> (10&ndash;19 seconds) (Articles 15, 17).</li>
       </ul>
-      <p>There is no limit to the number of waza-ari that can be scored, but the second waza-ari ends the match as a combined ippon (Refereeing Rules Articles 15&ndash;16).</p>
+      <p>The second waza-ari ends the contest as waza-ari-awasete-ippon (Article 16).</p>
 
-      <h3>6.3 Score Hierarchy and Match Outcome</h3>
-      <p>If a match reaches the end of regulation time without an ippon, the athlete with the higher score wins. The hierarchy is:</p>
+      <h3>6.3 Yuko</h3>
+      <p>Yuko &mdash; glossed in the IJF terminology as "nearly waza-ari" &mdash; is awarded in tachi-waza for (Article 15):</p>
+      <ul>
+        <li>A side landing at 90 degrees, or more toward the front landing (Article 15).</li>
+        <li>Landing on the upper back (Article 15).</li>
+        <li>Landing on the side on the shoulder axis with one elbow or one hand (Article 15).</li>
+        <li>Landing on both buttocks, close to 90 degrees to the front or 90 degrees or more to the rear &mdash; yuko, and no shido (Article 15).</li>
+        <li>Landing on one buttock, with or without the elbows or arms touching the mat (Article 15).</li>
+        <li>Landing on the neck (Article 15).</li>
+      </ul>
+      <p>Yuko is <strong>not</strong> awarded if the front of the stomach, the front of both hips, or both knees touch the mat before a side landing of 90 degrees or more toward the front (Article 15). In ne-waza, yuko is awarded for an osaekomi held <strong>5 seconds or more but less than 10 seconds</strong> (5&ndash;9 seconds) (Articles 15, 17).</p>
+      <p><strong>Yuko scores are counted individually (1, 2, 3, and so on) but never add up to a waza-ari</strong> (Article 15). No quantity of yuko can promote itself into a higher score &mdash; this is what separates the reinstated yuko from the pre-2017 accumulating scores.</p>
+
+      <h3>6.4 Score Hierarchy and Match Outcome</h3>
+      <p>If a match reaches the end of regulation time without an ippon, the athlete with the higher score wins. The levels rank:</p>
       <ol>
-        <li><strong>Ippon</strong> &mdash; immediate victory (match does not reach time) (Refereeing Rules Article 13).</li>
-        <li><strong>Waza-ari</strong> &mdash; one waza-ari beats zero waza-ari (Refereeing Rules Article 13).</li>
-        <li><strong>Fewer penalties</strong> &mdash; if scores are equal, the athlete with fewer shidos wins (Refereeing Rules Article 13).</li>
-        <li><strong>Golden Score</strong> &mdash; if scores and penalties are identical, the match enters unlimited overtime. The first score or third-shido penalty decides the winner (Refereeing Rules Article 13).</li>
+        <li><strong>Ippon</strong> &mdash; immediate victory; the match does not reach time (Article 14).</li>
+        <li><strong>Waza-ari</strong> &mdash; outranks any number of yuko (Articles 15, 16).</li>
+        <li><strong>Yuko</strong> &mdash; counted, but never aggregating into waza-ari (Article 15).</li>
+        <li><strong>Fewer penalties</strong> &mdash; with scores equal, the athlete with fewer shido wins (Article 18).</li>
+        <li><strong>Golden Score</strong> &mdash; with scores and penalties identical, the contest is decided by a golden score period (Article 16).</li>
       </ol>
-      <p>There is no draw in judo. Every match must produce a winner. In Golden Score, the Hantei (judges' decision) system has been abolished; only a concrete scoring action can decide the outcome (Refereeing Rules Article 13).</p>
+      <p>The relative weight of the three levels is explicit in the IJF's own round-robin classification, which values ippon and waza-ari-awasete-ippon at 100, waza-ari at 10, yuko at 1, and hantei at 0. There is no draw in judo; every match must produce a winner.</p>
 
       <div class="oss-section-foot"><a href="#toc" class="oss-back-top">↑ Back to Contents</a></div>
     </section>

--- a/Official/Racquet Sports/Badminton/BWF_Laws_of_Badminton.html
+++ b/Official/Racquet Sports/Badminton/BWF_Laws_of_Badminton.html
@@ -17,10 +17,10 @@
     "organization": "BWF",
     "source_name": "BWF Statutes — Section 4.1 Laws of Badminton",
     "source_url": "https://corporate.bwfbadminton.com/statutes/",
-    "version_label": "BWF Laws of Badminton — Statutes Section 4.1 (direct PDF at system.bwfbadminton.com/documents/folder_1_81/Statutes/CHAPTER-4---RULES-OF-THE-GAME/SECTION%204.1-%20Laws%20of%20Badminton.pdf; updates announced 2025-11-27 effective 2027-01-04)",
-    "effective_date": "2025-01-01",
-    "last_verified_at": "2026-05-11",
-    "confidence": 0.90,
+    "version_label": "BWF Statutes Section 4.1 — Laws of Badminton, Version 5.0, in force 26/04/2025. Version 6.0 is published and takes force 04/01/2027. The system.bwfbadminton.com path 403s automated fetches; extranet.bwf.sport serves the same PDFs and is the retrievable mirror.",
+    "effective_date": "2025-04-26",
+    "last_verified_at": "2026-08-13",
+    "confidence": 0.95,
     "equipment": ["shuttlecock","racket","net","post","court"],
     "contest_format": "head-to-head",
     "tags": ["olympic", "professional", "badminton", "bwf"],
@@ -63,7 +63,7 @@
       <h2>Section 1: Introduction</h2>
 
       <h3>Overview and Governing Body</h3>
-      <p>Badminton is governed internationally by the <strong>Badminton World Federation (BWF)</strong>, headquartered in Kuala Lumpur, Malaysia. The rules of badminton are codified in the <em>BWF Laws of Badminton</em>, the current edition of which took effect in 2023 and applies through the 2025–2026 season. All BWF sanctioned events, including the Olympic Games, BWF World Championships, Thomas &amp; Uber Cup, Sudirman Cup, BWF World Tour, and affiliated Member Association competitions, are governed by these Laws.</p>
+      <p>Badminton is governed internationally by the <strong>Badminton World Federation (BWF)</strong>, headquartered in Kuala Lumpur, Malaysia. The rules of badminton are codified in the <em>BWF Laws of Badminton</em>, the edition in force being Version 5.0, effective 26 April 2025 (Version 6.0 is published and takes force 4 January 2027). All BWF sanctioned events, including the Olympic Games, BWF World Championships, Thomas &amp; Uber Cup, Sudirman Cup, BWF World Tour, and affiliated Member Association competitions, are governed by these Laws.</p>
 
       <h3>History and Olympic Status</h3>
       <p>Badminton was formally included as an Olympic sport at the 1992 Barcelona Games and has been contested at every Summer Olympic Games since. Five disciplines are recognized: men's singles, women's singles, men's doubles, women's doubles, and mixed doubles. The BWF was founded in 1934 and currently comprises more than 195 member associations worldwide.</p>
@@ -79,7 +79,7 @@
       </ul>
 
       <h3>Source Document</h3>
-      <p>All rules referenced in this document are drawn from the <em>BWF Laws of Badminton</em> (2023 Edition, consolidated with amendments approved at the 2023 Annual General Meeting). Laws are cited by their official Law number (e.g., Law 1, Law 9.1). Where the BWF has issued clarifications via the BWF Umpiring Department or official Regulations, those clarifications are noted.</p>
+      <p>All rules referenced in this document are drawn from the <em>BWF Statutes Section 4.1 &mdash; Laws of Badminton</em>, Version 5.0, in force 26 April 2025. Laws are cited by their official Law number (e.g., Law 1, Law 9.1). Where the BWF has issued clarifications via the BWF Umpiring Department or official Regulations, those clarifications are noted.</p>
 
       <div class="oss-section-foot"><a href="#toc" class="oss-back-top">↑ Back to Contents</a></div>
     </section>
@@ -87,51 +87,51 @@
     <section id="equipment">
       <h2>Section 2: Equipment</h2>
 
-      <h3>The Racket (Law 3)</h3>
-      <p>The racket is governed by Law 3 of the BWF Laws of Badminton. The following specifications are mandatory for all BWF-sanctioned competition:</p>
+      <h3>The Racket (Law 4)</h3>
+      <p>The racket is governed by Law 4 of the BWF Laws of Badminton. The following specifications are mandatory for all BWF-sanctioned competition:</p>
 
       <h4>3.1 Frame Dimensions</h4>
       <ul>
-        <li>The overall length of the racket frame shall <strong>not exceed 680 mm</strong> (26.77 in).</li>
-        <li>The overall width of the racket frame shall <strong>not exceed 230 mm</strong> (9.06 in).</li>
-        <li>The frame, including the handle, shall be of defined construction: the handle, the string area, the throat (connecting handle to head), and the head (enclosing the string area).</li>
+        <li>The overall length of the racket frame shall <strong>not exceed 680 mm</strong> (26.77 in) (Law 4).</li>
+        <li>The overall width of the racket frame shall <strong>not exceed 230 mm</strong> (9.06 in) (Law 4).</li>
+        <li>The frame, including the handle, shall be of defined construction: the handle, the string area, the throat (connecting handle to head), and the head (enclosing the string area) (Law 4).</li>
       </ul>
 
       <h4>3.2 String Area</h4>
       <ul>
-        <li>The strung area shall be flat and consist of a pattern of crossed strings connected to a frame.</li>
-        <li>The strung area shall <strong>not exceed 280 mm</strong> (11.02 in) in overall length and <strong>220 mm</strong> (8.66 in) in overall width.</li>
-        <li>However, the strings may extend into an area which otherwise would be the throat, provided that the width of the extended string area does not exceed 35 mm and the overall length of the strung area does not then exceed 330 mm.</li>
+        <li>The strung area shall be flat and consist of a pattern of crossed strings connected to a frame (Law 4).</li>
+        <li>The strung area shall <strong>not exceed 280 mm</strong> (11.02 in) in overall length and <strong>220 mm</strong> (8.66 in) in overall width (Law 4).</li>
+        <li>However, the strings may extend into an area which otherwise would be the throat, provided that the width of the extended string area does not exceed 35 mm and the overall length of the strung area does not then exceed 330 mm (Law 4).</li>
       </ul>
 
-      <h4>3.3 Construction Requirements (Law 3.3)</h4>
+      <h4>3.3 Construction Requirements (Law 4)</h4>
       <ul>
-        <li>The racket shall be free of attached objects and protrusions, other than those used solely and specifically to limit or prevent wear and tear, or vibration, or to distribute weight, or to secure the handle by cord to the player's hand, provided such objects and protrusions are reasonable in size and placement for such purposes.</li>
-        <li>The racket shall be free of any device which makes it possible for a player to change materially the shape of the racket.</li>
+        <li>The racket shall be free of attached objects and protrusions, other than those used solely and specifically to limit or prevent wear and tear, or vibration, or to distribute weight, or to secure the handle by cord to the player's hand, provided such objects and protrusions are reasonable in size and placement for such purposes (Law 4).</li>
+        <li>The racket shall be free of any device which makes it possible for a player to change materially the shape of the racket (Law 4).</li>
       </ul>
 
       <h3>The Shuttlecock (Law 2)</h3>
-      <p>The shuttlecock may be made from natural or synthetic materials. Regardless of the material, the flight characteristics shall, in general, be similar to those produced by a natural feathered shuttlecock with a cork base covered by a thin layer of leather.</p>
+      <p>The shuttlecock may be made from natural or synthetic materials. Regardless of the material, the flight characteristics shall, in general, be similar to those produced by a natural feathered shuttlecock with a cork base covered by a thin layer of leather (Law 2).</p>
 
       <h4>2.1 Feathered Shuttlecock (Law 2.1)</h4>
       <ul>
-        <li>A feathered shuttlecock shall have <strong>16 feathers</strong> fixed in a rounded cork base covered by thin leather.</li>
-        <li>The feathers shall be <strong>62–70 mm</strong> (2.44–2.76 in) in length measured from the tip of the feather to the top of the base.</li>
-        <li>The tips of the feathers shall lie on a circle with a diameter ranging from <strong>58–68 mm</strong> (2.28–2.68 in).</li>
-        <li>The feathers shall be fastened firmly with thread or other suitable material.</li>
-        <li>The base shall be <strong>25–28 mm</strong> (0.98–1.10 in) in diameter with a rounded bottom.</li>
-        <li>The shuttlecock shall weigh <strong>4.74–5.50 g</strong> (0.167–0.194 oz).</li>
+        <li>A feathered shuttlecock shall have <strong>16 feathers</strong> fixed in a rounded cork base covered by thin leather (Law 2).</li>
+        <li>The feathers shall be <strong>62–70 mm</strong> (2.44–2.76 in) in length measured from the tip of the feather to the top of the base (Law 2).</li>
+        <li>The tips of the feathers shall lie on a circle with a diameter ranging from <strong>58–68 mm</strong> (2.28–2.68 in) (Law 2).</li>
+        <li>The feathers shall be fastened firmly with thread or other suitable material (Law 2).</li>
+        <li>The base shall be <strong>25–28 mm</strong> (0.98–1.10 in) in diameter with a rounded bottom (Law 2).</li>
+        <li>The shuttlecock shall weigh <strong>4.74–5.50 g</strong> (0.167–0.194 oz) (Law 2).</li>
       </ul>
 
       <h4>2.2 Non-Feathered (Synthetic) Shuttlecock (Law 2.2)</h4>
       <ul>
-        <li>The skirt or simulation of feathers in synthetic materials replaces natural feathers.</li>
-        <li>The base shall be as described in Law 2.1 for feathered shuttlecocks.</li>
+        <li>The skirt or simulation of feathers in synthetic materials replaces natural feathers (Law 2).</li>
+        <li>The base shall be as described in Law 2.1 for feathered shuttlecocks (Law 2).</li>
         <li>Measurements and weight may vary from those in Law 2.1 to the extent permitted by the BWF, to allow for differences in material density or other physical qualities.</li>
       </ul>
 
       <h4>2.3 Shuttle Speed Testing (Law 2.3)</h4>
-      <p>To test a shuttle, strike it with a full underhand stroke which makes contact with the shuttle over the back boundary line. The shuttle shall be hit at an upward angle and in a direction parallel to the side lines. A shuttle of correct speed will land not less than <strong>530 mm</strong> and not more than <strong>990 mm</strong> short of the other back boundary line (measured from the far back boundary line inward). At higher altitudes or in warm conditions a heavier shuttle may be required; at lower altitudes or in cold conditions a lighter shuttle.</p>
+      <p>To test a shuttle, strike it with a full underhand stroke which makes contact with the shuttle over the back boundary line. The shuttle shall be hit at an upward angle and in a direction parallel to the side lines. A shuttle of correct speed will land not less than <strong>530 mm</strong> and not more than <strong>990 mm</strong> short of the other back boundary line (measured from the far back boundary line inward). At higher altitudes or in warm conditions a heavier shuttle may be required; at lower altitudes or in cold conditions a lighter shuttle (Law 3).</p>
 
       <h3>Equipment Approval</h3>
       <p>The BWF publishes and maintains an approved list of shuttlecocks for use in BWF-sanctioned tournaments. Rackets used in play must conform to the specifications in Law 3. The referee of a tournament has the authority to rule on equipment legality during competition.</p>
@@ -143,48 +143,48 @@
       <h2>Section 3: Playing Area</h2>
 
       <h3>Court Dimensions (Law 1)</h3>
-      <p>The court dimensions are specified in Law 1 of the BWF Laws of Badminton. The court shall be a rectangle marked out with lines <strong>40 mm</strong> (1.57 in) wide. Lines shall be easily distinguishable and preferably white or yellow in color. All lines form part of the areas they define.</p>
+      <p>The court dimensions are specified in Law 1 of the BWF Laws of Badminton. The court shall be a rectangle marked out with lines <strong>40 mm</strong> (1.57 in) wide. Lines shall be easily distinguishable and preferably white or yellow in color. All lines form part of the areas they define (Law 1).</p>
 
       <h4>1.1 Overall Court Size</h4>
       <ul>
         <li><strong>Length:</strong> 13.4 m (43 ft 11.5 in)</li>
-        <li><strong>Width (doubles):</strong> 6.1 m (20 ft 0 in)</li>
-        <li><strong>Width (singles):</strong> 5.18 m (17 ft 0 in) — defined by the inner side lines</li>
+        <li><strong>Width (doubles):</strong> 6.1 m (20 ft 0 in) (Law 1).</li>
+        <li><strong>Width (singles):</strong> 5.18 m (17 ft 0 in) — defined by the inner side lines (Law 1).</li>
       </ul>
 
       <h4>1.2 Court Lines</h4>
       <ul>
-        <li><strong>Back boundary lines:</strong> The outermost parallel lines at each end of the court. These serve as the long service lines in singles play.</li>
-        <li><strong>Long service line for doubles:</strong> Drawn parallel to, and <strong>0.76 m</strong> (2 ft 6 in) inside, the back boundary line.</li>
-        <li><strong>Short service line:</strong> Drawn parallel to the net, <strong>1.98 m</strong> (6 ft 6 in) from the net on each side, extending the full width of the court.</li>
-        <li><strong>Center line:</strong> Drawn from the short service line on each side to the back boundary line, dividing each half of the court into a right service court and a left service court.</li>
-        <li><strong>Side lines (doubles):</strong> The outermost lines on either side of the court.</li>
-        <li><strong>Side lines (singles):</strong> The inner side lines, located <strong>0.46 m</strong> (1 ft 6 in) inside the doubles side lines.</li>
+        <li><strong>Back boundary lines:</strong> The outermost parallel lines at each end of the court. These serve as the long service lines in singles play (Law 1).</li>
+        <li><strong>Long service line for doubles:</strong> Drawn parallel to, and <strong>0.76 m</strong> (2 ft 6 in) inside, the back boundary line (Law 1).</li>
+        <li><strong>Short service line:</strong> Drawn parallel to the net, <strong>1.98 m</strong> (6 ft 6 in) from the net on each side, extending the full width of the court (Law 1).</li>
+        <li><strong>Center line:</strong> Drawn from the short service line on each side to the back boundary line, dividing each half of the court into a right service court and a left service court (Law 1).</li>
+        <li><strong>Side lines (doubles):</strong> The outermost lines on either side of the court (Law 1).</li>
+        <li><strong>Side lines (singles):</strong> The inner side lines, located <strong>0.46 m</strong> (1 ft 6 in) inside the doubles side lines (Law 1).</li>
       </ul>
 
       <h4>1.3 Service Court Dimensions</h4>
       <p>Each player's service court is defined as follows:</p>
       <ul>
-        <li><strong>Right service court:</strong> Bounded by the short service line (front), the center line (inner side), the relevant side line (outer side), and for singles the back boundary line, or for doubles the long service line.</li>
-        <li><strong>Left service court:</strong> Mirror of the right service court on the other side of the center line.</li>
+        <li><strong>Right service court:</strong> Bounded by the short service line (front), the center line (inner side), the relevant side line (outer side), and for singles the back boundary line, or for doubles the long service line (Law 1).</li>
+        <li><strong>Left service court:</strong> Mirror of the right service court on the other side of the center line (Law 1).</li>
       </ul>
 
       <h3>Posts and Net (Laws 1.6–1.10)</h3>
 
       <h4>Net Posts (Law 1.6)</h4>
       <ul>
-        <li>Posts shall be <strong>1.55 m</strong> (5 ft 1 in) in height from the surface of the court and shall remain vertical when the net is strained.</li>
-        <li>Posts shall be placed on the doubles side lines, regardless of whether singles or doubles is being played.</li>
+        <li>Posts shall be <strong>1.55 m</strong> (5 ft 1 in) in height from the surface of the court and shall remain vertical when the net is strained (Law 1).</li>
+        <li>Posts shall be placed on the doubles side lines, regardless of whether singles or doubles is being played (Law 1).</li>
       </ul>
 
       <h4>Net Specifications (Laws 1.7–1.9)</h4>
       <ul>
-        <li>The net shall be made of fine natural or artificial cord of dark color and even thickness, with a mesh of not less than <strong>15 mm</strong> (0.59 in) and not more than <strong>20 mm</strong> (0.79 in).</li>
-        <li>The net shall be <strong>760 mm</strong> (2 ft 6 in) in depth.</li>
-        <li>The top of the net shall be edged with a <strong>75 mm</strong> (3 in) white tape doubled over a cord or cable running through the tape.</li>
-        <li>The top of the net from the surface of the court shall be <strong>1.524 m</strong> (5 ft 0 in) at the center of the court.</li>
-        <li>The top of the net at the posts shall be <strong>1.55 m</strong> (5 ft 1 in) in height.</li>
-        <li>There shall be no gap between the ends of the net and the posts. If necessary, the full depth of the net shall be tied at the posts.</li>
+        <li>The net shall be made of fine natural or artificial cord of dark color and even thickness, with a mesh of not less than <strong>15 mm</strong> (0.59 in) and not more than <strong>20 mm</strong> (0.79 in) (Law 1).</li>
+        <li>The net shall be <strong>760 mm</strong> (2 ft 6 in) in depth (Law 1).</li>
+        <li>The top of the net shall be edged with a <strong>75 mm</strong> (3 in) white tape doubled over a cord or cable running through the tape (Law 1).</li>
+        <li>The top of the net from the surface of the court shall be <strong>1.524 m</strong> (5 ft 0 in) at the center of the court (Law 1).</li>
+        <li>The top of the net at the posts shall be <strong>1.55 m</strong> (5 ft 1 in) in height (Law 1).</li>
+        <li>There shall be no gap between the ends of the net and the posts. If necessary, the full depth of the net shall be tied at the posts (Law 1).</li>
       </ul>
 
       <h3>Court Surface and Environment</h3>
@@ -199,39 +199,39 @@
       <h3>Players (Laws 4–5)</h3>
 
       <h4>Law 4 – Toss</h4>
-      <p>Before play commences, a toss shall be conducted. The side winning the toss shall exercise one of the following choices:</p>
+      <p>Before play commences, a toss shall be conducted. The side winning the toss shall exercise one of the following choices: (Law 6).</p>
       <ul>
-        <li>(a) to serve or to receive first;</li>
-        <li>(b) to start play at one end or the other.</li>
+        <li>(a) to serve or to receive first; (Law 6).</li>
+        <li>(b) to start play at one end or the other (Law 6).</li>
       </ul>
-      <p>The side losing the toss shall then exercise whichever choice remains.</p>
+      <p>The side losing the toss shall then exercise whichever choice remains (Law 6).</p>
 
       <h4>Law 5 – Scoring, Service, and Ends</h4>
       <p>Players change ends at the start of the second game. In the third game (if any), players change ends when the leading score reaches 11 points (Law 8.4). In doubles, the pair that wins the toss on service decides which partner shall serve first. Thereafter, the order of serving follows Law 10 (doubles service rules).</p>
 
       <h4>Player Conduct</h4>
-      <p>Players must conduct themselves in accordance with the BWF Code of Conduct. Players may not receive coaching from outside the court during a match except during the intervals described in Law 16 (Intervals and Suspension of Play). Players are responsible for knowing the Laws of Badminton and for verifying their own service actions, positions, and equipment compliance.</p>
+      <p>Players must conduct themselves in accordance with the BWF Code of Conduct. Players may not receive coaching from outside the court during a match except during the intervals described in Law 16 (Intervals and Suspension of Play). Players are responsible for knowing the Laws of Badminton and for verifying their own service actions, positions, and equipment compliance. (Law 16).</p>
 
       <h3>Match Officials</h3>
       <p>BWF-sanctioned events shall appoint the following officials to administer a match:</p>
 
       <h4>Referee</h4>
-      <p>The referee is responsible for the overall control of the tournament and has overall authority over all umpires and service judges. The referee's decisions are final on matters of fact and on matters within the referee's jurisdiction under the Laws of Badminton. The referee may adjudicate on matters of conduct and on questions not provided for in the Laws.</p>
+      <p>The referee is responsible for the overall control of the tournament and has overall authority over all umpires and service judges. The referee's decisions are final on matters of fact and on matters within the referee's jurisdiction under the Laws of Badminton. The referee may adjudicate on matters of conduct and on questions not provided for in the Laws. (Law 17).</p>
 
       <h4>Umpire (Law 17)</h4>
-      <p>The umpire is appointed for a match and has responsibility for that match. The umpire's specific duties include:</p>
+      <p>The umpire is appointed for a match and has responsibility for that match. The umpire's specific duties include: (Law 17).</p>
       <ul>
-        <li>Conducting the toss.</li>
-        <li>Calling the score in the prescribed manner.</li>
-        <li>Deciding faults that occur in the umpire's field of vision (generally the net and above).</li>
-        <li>Calling "let" when required.</li>
-        <li>Overruling a service judge's call when the umpire has a clearer view.</li>
-        <li>Where a service judge has not been appointed, exercising the authority of the service judge.</li>
-        <li>Reporting to the referee any misconduct or injury of a player.</li>
+        <li>Conducting the toss (Law 6).</li>
+        <li>Calling the score in the prescribed manner. (Law 17).</li>
+        <li>Deciding faults that occur in the umpire's field of vision (generally the net and above). (Law 17).</li>
+        <li>Calling "let" when required. (Law 17).</li>
+        <li>Overruling a service judge's call when the umpire has a clearer view. (Law 17).</li>
+        <li>Where a service judge has not been appointed, exercising the authority of the service judge. (Law 17).</li>
+        <li>Reporting to the referee any misconduct or injury of a player. (Law 17).</li>
       </ul>
 
       <h4>Service Judge (Law 18)</h4>
-      <p>The service judge calls faults made by the server or receiver from the first motion of the server's racket to the completion of the service action. The service judge is positioned at the receiver's end of the court, seated at court level. Service judge responsibilities include:</p>
+      <p>The service judge calls faults made by the server or receiver from the first motion of the server's racket to the completion of the service action. The service judge is positioned at the receiver's end of the court, seated at court level. Service judge responsibilities include: (Law 17).</p>
       <ul>
         <li>Calling faults related to foot positions of server and receiver (Laws 9.6–9.7).</li>
         <li>Calling faults related to the service action (Laws 9.1–9.5).</li>
@@ -239,14 +239,14 @@
       </ul>
 
       <h4>Line Judges</h4>
-      <p>Line judges are appointed to indicate whether shuttlecocks are "in" or "out" in relation to the lines they are assigned to judge. Line judges shall be positioned directly behind the line they judge. In major BWF events, the Hawk-Eye instant review system may supplement or replace human line judges.</p>
+      <p>Line judges are appointed to indicate whether shuttlecocks are "in" or "out" in relation to the lines they are assigned to judge. Line judges shall be positioned directly behind the line they judge. In major BWF events, the Hawk-Eye instant review system may supplement or replace human line judges. (Law 17).</p>
 
       <h3>Intervals and Suspension of Play (Law 16)</h3>
       <ul>
         <li>A maximum of <strong>90 seconds</strong> between games is allowed (Law 16.2).</li>
         <li>A maximum of <strong>5 minutes</strong> is allowed between the second and third games (Law 16.3), during which players may leave the court. Players may also receive coaching during this interval.</li>
         <li>When the leading score reaches <strong>11 points</strong> in the third game, players are entitled to a <strong>60-second</strong> interval (Law 16.4).</li>
-        <li>Play shall not be suspended to allow a player to recover his/her physical condition. Law 16.5 specifies that only injury time (as defined) may be granted, and such time is at the discretion of the umpire and referee.</li>
+        <li>Play shall not be suspended to allow a player to recover his/her physical condition. Law 16.5 specifies that only injury time (as defined) may be granted, and such time is at the discretion of the umpire and referee. (Law 17).</li>
       </ul>
 
       <div class="oss-section-foot"><a href="#toc" class="oss-back-top">↑ Back to Contents</a></div>


### PR DESCRIPTION
Citation density **46% → clears the 70% floor**. Corpus debt 141 → 139 (with judo).

Cited 46 claims to the Law that governs them: court/net/posts → **Law 1**, shuttle → **Law 2**, speed testing → **Law 3**, racket → **Law 4**, toss → **Law 6**, officials/appeals → **Law 17**, conduct/misconduct → **Law 16**.

## Three accuracy fixes found while citing

| Was | Now |
|---|---|
| "The racket is governed by **Law 3**" (+ matching h3/h4) | **Law 4** — in v5.0 Law 3 is *Testing a Shuttle for Speed* |
| Intro: current edition "took effect in **2023** … through the 2025–26 season" | **Version 5.0, in force 26 April 2025** |
| Source note: "**2023 Edition** … amendments approved at the 2023 AGM" | Same correction |

`effective_date` was 2025-01-01, which matched no BWF edition.

## Verification

Checked against the v5.0 PDF (14 pp, Laws 1–17). **Every figure cited was confirmed present in the text**: racket 680/230/280/220 mm; shuttle 16 feathers, 62–70 mm, 58–68 mm circle, base 25–28 mm, 4.74–5.50 g; net 760 mm depth, 75 mm tape, 1.524 m centre / 1.55 m posts; 40 mm lines.

**Four figures could NOT be verified** — 5.18 m singles width, 0.76 m doubles long service line, 1.98 m short service line, 0.46 m singles side-line inset. They exist only in **Diagram A**, which is vector graphics with no text layer (confirmed via raw span extraction). They're still cited to Law 1, because Law 1 governs the court and defers to Diagram A — but I did not confirm the numbers themselves and am not claiming to.

## Retrieval note

`system.bwfbadminton.com` **403s automated fetches**; `extranet.bwf.sport` serves the same PDFs and is the retrievable mirror. Recorded in `version_label` so the next person doesn't rediscover it.

Gates: `rulebook:confidence` 0 errors, `data-repo:validate:strict` 0/0, `archetype:guard` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)