### PR TITLE
ci(sync): reach the origin directly so cloudflare cannot block the sync

### DIFF
--- a/.github/workflows/sync-app.yml
+++ b/.github/workflows/sync-app.yml
@@ -7,25 +7,82 @@ on:
       - 'Official/**'
       - 'Custom/**'
       - 'metadata.json'
+  workflow_dispatch:
+
+env:
+  # Hetzner origin behind Cloudflare. The sync trigger resolves straight to it
+  # (see "Why origin-direct" below).
+  ORIGIN_IP: 5.161.41.110
+  HOST: opensourcesports.io
 
 jobs:
   sync:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
+      # ─────────────────────────────────────────────────────────────────────
+      # Why origin-direct (`curl --resolve`) rather than the public URL:
+      #
+      # Cloudflare 403s GitHub Actions runner IPs. This workflow failed on
+      # every one of its last 5 runs (2026-08-09 .. 2026-08-15) — each one a
+      # `403` returned in ~0.2s, far too fast to have reached the origin. The
+      # route's own bearer check returns 401, not 403, so this was never an
+      # auth problem: the request never arrived.
+      #
+      # The consequence was silent. Merges landed on main, the workflow ran,
+      # went red, and no rulebook correction reached the site — the two most
+      # recent (judo yuko, badminton citations) had to be synced by hand.
+      #
+      # The sibling repo's deploy-verify.yml hit the identical wall (red on 16
+      # of 20 runs) and was fixed the same way. Keep the two in step: if one
+      # changes how it reaches the origin, change the other.
+      #
+      # TLS still validates against ${HOST} because --resolve only overrides
+      # DNS, not SNI or certificate verification.
+      # ─────────────────────────────────────────────────────────────────────
       - name: Trigger sync
         run: |
-          response=$(curl -s -o /dev/null -w "%{http_code}" \
-            -X POST "https://opensourcesports.io/api/sync" \
+          echo "Triggering sync at origin ${ORIGIN_IP} (host ${HOST})..."
+
+          # Deliberately NOT force=true. A plain sync uses content-hash change
+          # detection and touches only files that actually changed; a forced
+          # sync rewrites every rulebook row and appends a spurious
+          # rule_versions entry to all ~195 sports.
+          resp=$(curl -s --max-time 170 -w $'\n%{http_code}' \
+            --resolve "${HOST}:443:${ORIGIN_IP}" \
+            -X POST "https://${HOST}/api/sync" \
             -H "Authorization: Bearer ${{ secrets.SYNC_SECRET }}" \
-            -H "Content-Type: application/json" \
-            --max-time 120)
-          echo "Sync response: $response"
-          if [ "$response" -ge 200 ] && [ "$response" -lt 300 ]; then
-            echo "Sync triggered successfully"
-          elif [ "$response" = "409" ]; then
-            echo "Sync already in progress — OK"
-          else
-            echo "Sync failed with status $response"
-            exit 1
-          fi
+            -H "Content-Type: application/json" 2>/dev/null || printf '\n000')
+
+          status="${resp##*$'\n'}"
+          body="${resp%$'\n'*}"
+
+          echo "Sync response: ${status}"
+          echo "Body: ${body}"
+
+          case "$status" in
+            2??)
+              echo "Sync triggered successfully"
+              ;;
+            409)
+              echo "Sync already in progress — OK"
+              ;;
+            403)
+              # Should be unreachable now that we bypass the edge. If it fires,
+              # the origin itself is rejecting us — do not paper over it.
+              echo "::error::403 from the ORIGIN, not the edge. The bypass is working but the origin refused the request."
+              exit 1
+              ;;
+            401)
+              echo "::error::401 Unauthorized — the SYNC_SECRET repo secret no longer matches the value in the app container."
+              exit 1
+              ;;
+            000)
+              echo "::error::No response (timeout or connection failure) from ${ORIGIN_IP}. Check the origin is up and ORIGIN_IP is current."
+              exit 1
+              ;;
+            *)
+              echo "::error::Sync failed with status ${status}"
+              exit 1
+              ;;
+          esac


### PR DESCRIPTION
The auto-sync has been broken for at least 6 days and failing silently. This ports the fix already proven in the app repo's `deploy-verify.yml`.

## The failure

`sync-app.yml` failed on **all 5** of its last runs (2026-08-09 → 2026-08-15):

```
Sync response: 403
Sync failed with status 403
```

Returned in **~0.2s** — far too fast to have reached the Hetzner origin. And the sync route's own bearer check returns **401**, not 403. So this was never an auth problem: Cloudflare was 403ing the GitHub Actions runner IPs and the request never arrived.

## Why it mattered

The failure mode was silent in the way that counts. Merges landed on `main`, the workflow ran, went red, and **no rulebook correction reached the live site**. The two most recent — the judo yuko reinstatement (#17) and the badminton citations (#18) — both had to be synced by hand after merging. Anyone reading `app-registry.yaml` would still see "auto-syncs via GitHub Action".

## The fix

`curl --resolve` pins the hostname to the origin IP so the edge is never in the path. `deploy-verify.yml` in the sibling repo hit the identical wall — red on 16 of its last 20 runs — and was fixed exactly this way. TLS still validates against the real host, because `--resolve` overrides DNS only, not SNI or certificate verification.

Also splits the failure cases apart, since `Sync failed with status N` gave no way to tell a blocked edge from a rotated secret:

| Status | Now means |
|---|---|
| `2xx` | synced |
| `409` | already in progress — OK |
| `403` | the **origin** refused; bypass worked, something else is wrong |
| `401` | `SYNC_SECRET` has drifted from the app container |
| `000` | origin unreachable / `ORIGIN_IP` stale |

Adds `workflow_dispatch` so a failed sync can be retried without pushing an empty commit.

Kept deliberately: **no `force=true`**. A plain sync uses content-hash change detection; a forced sync rewrites every rulebook row and appends a spurious `rule_versions` entry to all ~195 sports.

## Verification

Origin-direct POST with a deliberately invalid token:

```
{"error":"Unauthorized"}
HTTP=401 time=0.150993s
```

401 from the route handler rather than 403 from the edge — the request reaches the app. Contrast with the 403-in-0.2s the runner was getting.

A real origin-direct sync (run by hand while diagnosing this) returned:

```json
{"synced":2,"skipped":193,"errors":[],
 "syncedSlugs":["judo-ijf","badminton-bwf"]}
```

## Note

`ORIGIN_IP` is now pinned in two workflows across two repos. If the Hetzner origin ever moves, both need updating — called out in the inline comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)