### PR TITLE
[UPDATE] fix: cite the badminton court dimensions to Diagram A, not Law 1 text

### DIFF
--- a/Official/Racquet Sports/Badminton/BWF_Laws_of_Badminton.html
+++ b/Official/Racquet Sports/Badminton/BWF_Laws_of_Badminton.html
@@ -147,19 +147,19 @@
 
       <h4>1.1 Overall Court Size</h4>
       <ul>
-        <li><strong>Length:</strong> 13.4 m (43 ft 11.5 in)</li>
-        <li><strong>Width (doubles):</strong> 6.1 m (20 ft 0 in) (Law 1).</li>
-        <li><strong>Width (singles):</strong> 5.18 m (17 ft 0 in) — defined by the inner side lines (Law 1).</li>
+        <li><strong>Length:</strong> 13.4 m (43 ft 11.5 in) (Law 1, Diagram A).</li>
+        <li><strong>Width (doubles):</strong> 6.1 m (20 ft 0 in) (Law 1, Diagram A).</li>
+        <li><strong>Width (singles):</strong> 5.18 m (17 ft 0 in) — defined by the inner side lines (Law 1, Diagram A).</li>
       </ul>
 
       <h4>1.2 Court Lines</h4>
       <ul>
         <li><strong>Back boundary lines:</strong> The outermost parallel lines at each end of the court. These serve as the long service lines in singles play (Law 1).</li>
-        <li><strong>Long service line for doubles:</strong> Drawn parallel to, and <strong>0.76 m</strong> (2 ft 6 in) inside, the back boundary line (Law 1).</li>
-        <li><strong>Short service line:</strong> Drawn parallel to the net, <strong>1.98 m</strong> (6 ft 6 in) from the net on each side, extending the full width of the court (Law 1).</li>
+        <li><strong>Long service line for doubles:</strong> Drawn parallel to, and <strong>0.76 m</strong> (2 ft 6 in) inside, the back boundary line (Law 1, Diagram A).</li>
+        <li><strong>Short service line:</strong> Drawn parallel to the net, <strong>1.98 m</strong> (6 ft 6 in) from the net on each side, extending the full width of the court (Law 1, Diagram A).</li>
         <li><strong>Center line:</strong> Drawn from the short service line on each side to the back boundary line, dividing each half of the court into a right service court and a left service court (Law 1).</li>
         <li><strong>Side lines (doubles):</strong> The outermost lines on either side of the court (Law 1).</li>
-        <li><strong>Side lines (singles):</strong> The inner side lines, located <strong>0.46 m</strong> (1 ft 6 in) inside the doubles side lines (Law 1).</li>
+        <li><strong>Side lines (singles):</strong> The inner side lines, located <strong>0.46 m</strong> (1 ft 6 in) inside the doubles side lines (Law 1, Diagram A).</li>
       </ul>
 
       <h4>1.3 Service Court Dimensions</h4>


### PR DESCRIPTION
Closes the last open item flagged in the 2026-08-15 handoff: four badminton figures "cited but unverified". Verified now — at the source.

## What the Laws actually say

I pulled the **BWF Laws of Badminton** PDF and extracted its text. Law 1's **prose** contains exactly three measurements:

| In the text | Value |
|---|---|
| line width | 40 mm |
| posts | 1.55 m |
| net at centre | 1.524 m |

The court dimensions — `13.4` / `6.1` / `5.18` / `1.98` / `0.76` / `0.46 m` — return **zero hits**. They exist only in **Diagram A**, a vector drawing with no extractable text labels.

So `(Law 1)` was not *false* — Law 1 governs the court and says explicitly *"as shown in Diagram A"* — but it implied the numbers were read out of the Law's text, which is impossible. Same shape as the luge Wikipedia fix in the app repo: **the fact is right, the citation overstates what was checked.**

## The figures are sound and unchanged

Internally consistent — (6.1 − 5.18) / 2 = **0.46 exactly** — and matching the universally published court. This PR changes provenance, not values.

## Scoping

Six bullets now cite `(Law 1, Diagram A)`. Deliberately **not** touched:

- prose-sourced figures (40 mm, 1.55 m, 1.524 m) keep their bare `(Law 1)`
- definitional bullets that *describe* lines rather than measure them (back boundary, centre line, service courts) keep theirs

`Length: 13.4 m` had **no citation at all** — missed by the earlier citation pass. It now carries one.

## Two traps worth recording

**Automated PDF summarisation confabulated.** Asked to read Law 1 from this exact PDF, it returned **tennis** dimensions (23.77 × 10.97 m, 8.23 m singles). The document was genuinely the BWF Laws; the summary invented a different sport. Caught only because the numbers are obviously wrong for badminton — a subtler error would have passed.

**`13.4` does occur in the Laws text** — as *clause* 13.4, not the court length. Grepping the bare number would have "confirmed" a dimension that isn't there.

## Verification

```
data-repo:validate      195 files, 0 errors, 0 warnings
rulebook:confidence     161 rulebooks, 0 errors — badminton does not regress
diff                    1 file, 6 insertions, 6 deletions
```

## Note on merge

This edits rulebook HTML, so the content hash changes — merging triggers a sync and appends a `rule_versions` row, unlike the migration-only work in the app repo. The sync workflow was fixed in #19, so this should ingest automatically rather than needing a manual run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)